### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 ## 發文方法
 發文請至 [https://init.kobeengineer.io/](https://init.kobeengineer.io/)
 
-本站發文需具備 [Github](https://github.com) 或  [Bitbuchet](bitbucket.org) 帳號
+本站發文需具備 [GitHub](https://github.com) 或  [Bitbucket](bitbucket.org) 帳號
 
 且需符合相關認證條件，始可使用發文功能
 
 ## 訂閱發文
 目前您可以在以下平台上觀看發文：
-- [Offical wesite](https://init.kobeengineer.io/feed/)
+- [Official website](https://init.kobeengineer.io/feed/)
 - [Facebook](https://www.facebook.com/init.kobeengineer)
 - [Twitter](https://twitter.com/inikobeengineer)
-- [Github](https://github.com/kobeengineer/init)
+- [GitHub](https://github.com/kobeengineer/init)


### PR DESCRIPTION
`Github` -> `GitHub` in line 12 and 21
`Bitbuchet` -> `Bitbucket` in line 12
`Offical wesite` -> `Official website` in line 18